### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/src/Georggi/RegionDefend/Main.php
+++ b/src/Georggi/RegionDefend/Main.php
@@ -24,13 +24,9 @@ use pocketmine\Server;
 class Main extends PluginBase implements Listener {
     public function onEnable() {
         $this->getServer()->getPluginManager()->registerEvents($this,$this);
+        $this->saveDefaultConfig();
         if(!file_exists($this->getDataFolder() . "regions.dat")) {
-            @mkdir($this->getDataFolder());
             file_put_contents($this->getDataFolder() . "regions.dat",yaml_emit(array()));
-        }
-        if(!file_exists($this->getDataFolder() . "config.yml")) {
-            @mkdir($this->getDataFolder());
-            file_put_contents($this->getDataFolder() . "config.yml",$this->getResource("config.yml"));
         }
         $this->regions = array();
         $this->regiondata = yaml_parse(file_get_contents($this->getDataFolder() . "regions.dat"));


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:

* `Plugin->getResource()` without `fclose()` calls later
* Not needed `Plugin->getResource()` calls
* `fopen()` calls without `fclose()`
* `popen()` calls without `pclose()`